### PR TITLE
Add finish call in environment

### DIFF
--- a/environment.sv
+++ b/environment.sv
@@ -125,6 +125,7 @@ class environment;
     
     -> test_done;  // Signal test completion
     $display("[Environment] Post-test cleanup completed at %0t", $time);
+    $finish;  // End the simulation once cleanup is done
   endtask
 
   // Task to start all components


### PR DESCRIPTION
## Summary
- ensure simulation ends once the environment is done

## Testing
- `iverilog -g2012 -f build.list -o simv` *(fails: syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_6878cf4ca47083299535d426892c1203