### PR TITLE
Fix driver reset comment

### DIFF
--- a/driver.sv
+++ b/driver.sv
@@ -26,7 +26,7 @@ class driver;
     $display("[Driver] Reset Started"); // Display a message indicating reset start
     vif.rst <= 1; // Assert the reset signal
     vif.drv_cb.enable <= 0; // Disable the driver callback
-    vif.drv_cb.rd_wr <= 0; // Set read/write to read
+    vif.drv_cb.rd_wr <= 0; // rd_wr <= 0 selects a write operation
     vif.drv_cb.addr <= '0; // Clear the address
     vif.drv_cb.wr_data <= '0; // Clear the write data
     repeat(5) @(posedge vif.clk); // Hold reset for 5 clock cycles


### PR DESCRIPTION
## Summary
- update comment in `driver.sv` reset task so that `rd_wr <= 0` explicitly indicates a write operation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878d0e579688329945c24d764ec5092