### PR TITLE
Compile environment separately for direct test

### DIFF
--- a/build.list
+++ b/build.list
@@ -13,7 +13,7 @@ environment.sv
 
 // 3) Test programs (one or more)
 test.sv
-//direct_test.sv
+direct_test.sv
 
 // 4) Top-level testbench
 testbench.sv

--- a/direct_test.sv
+++ b/direct_test.sv
@@ -17,8 +17,6 @@
 * - Address 3 (EXECUTE_REG): Execute bit [0], bits [7:1] reserved
 *******************************************************************************/
 
-`include "environment.sv"
-
 program direct_test(mem_if vif);
 
   initial begin


### PR DESCRIPTION
## Summary
- remove include of `environment.sv` inside `direct_test.sv`
- compile `direct_test.sv` via `build.list` so `environment.sv` is compiled separately

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878d50b94808329b005e9d7eb464223